### PR TITLE
fix: pass --format parameter which is currently ignored

### DIFF
--- a/internal/cmd/filter.go
+++ b/internal/cmd/filter.go
@@ -75,6 +75,7 @@ document should be VEX'ed by specifying --product=PRODUCT_ID.
 			ctx := context.Background()
 			vexctl := ctl.New()
 			vexctl.Options.Products = opts.products
+			vexctl.Options.Format = opts.reportFormat
 
 			// TODO: Autodetect piped stdin
 			reportFileName := args[0]


### PR DESCRIPTION
```release-note
Fixed a bug where the `--format` parameter was being ignored
```