### PR TITLE
Wrap VEX data open errors

### DIFF
--- a/pkg/ctl/ctl.go
+++ b/pkg/ctl/ctl.go
@@ -61,7 +61,7 @@ func (vexctl *VexCtl) Apply(r *sarif.Report, vexDocs []*vex.VEX) (finalReport *s
 func (vexctl *VexCtl) Attest(vexDataPath string, imageRefs []string) (*attestation.Attestation, error) {
 	doc, err := vexctl.impl.OpenVexData(vexctl.Options, []string{vexDataPath})
 	if err != nil {
-		return nil, fmt.Errorf("opening vex data")
+		return nil, fmt.Errorf("opening vex data: %w", err)
 	}
 
 	// Generate the attestation


### PR DESCRIPTION
This commit wraps errors coming from VEX open calls to get more insight when there is a problem opening vex data files.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>