### PR TITLE
Update VEX struct to latest model

### DIFF
--- a/pkg/vex/statement.go
+++ b/pkg/vex/statement.go
@@ -14,15 +14,34 @@ import (
 
 // A Statement is a declaration conveying a single [status] for a single [vul_id] for one or more [product_id]s. A VEX Statement exists within a VEX Document.
 type Statement struct {
-	Vulnerability string `json:"vulnerability"`
+	// [vul_id] SHOULD use existing and well known identifiers, for example:
+	// CVE, the Global Security Database (GSD), or a supplier’s vulnerability
+	// tracking system. It is expected that vulnerability identification systems
+	// are external to and maintained separately from VEX.
+	//
+	// [vul_id] MAY be URIs or URLs.
+	// [vul_id] MAY be arbitrary and MAY be created by the VEX statement [author].
+	Vulnerability   string `json:"vulnerability"`
+	VulnDescription string `json:"vuln_description,omitempty"`
 
-	// Timestamp is the time at which the information expressed in the Statement was known to be true.
+	// Timestamp is the time at which the information expressed in the Statement
+	// was known to be true.
 	Timestamp time.Time `json:"timestamp"`
+
+	// ProductIdentifiers
+	// Product details MUST specify what Status applies to.
+	// Product details MUST include [product_id] and MAY include [subcomponent_id].
+	Products      []string `json:"products"`
+	Subcomponents []string `json:"subcomponents,omitempty"`
 
 	// A VEX statement MUST provide Status of the vulnerabilities with respect to the
 	// products and components listed in the statement. Status MUST be one of the
 	// Status const values, some of which have further options and requirements.
 	Status Status `json:"status"`
+
+	// [status_notes] MAY convey information about how [status] was determined
+	// and MAY reference other VEX information.
+	StatusNotes string `json:"status_notes,omitempty"`
 
 	// For ”not_affected” status, a VEX statement MUST include a status Justification
 	// that further explains the status.
@@ -34,9 +53,8 @@ type Statement struct {
 
 	// For "affected" status, a VEX statement MUST include an ActionStatement that
 	// SHOULD describe actions to remediate or mitigate [vul_id].
-	ActionStatement string `json:"action_statement,omitempty"`
-
-	References []VulnerabilityReference `json:"references,omitempty"` // Optional list
+	ActionStatement          string    `json:"action_statement,omitempty"`
+	ActionStatementTimeStamp time.Time `json:"action_statement_timestamp,omitempty"`
 }
 
 // Validate checks to see whether the given Statement is valid. If it's not, an

--- a/pkg/vex/statement.go
+++ b/pkg/vex/statement.go
@@ -54,7 +54,7 @@ type Statement struct {
 	// For "affected" status, a VEX statement MUST include an ActionStatement that
 	// SHOULD describe actions to remediate or mitigate [vul_id].
 	ActionStatement          string    `json:"action_statement,omitempty"`
-	ActionStatementTimeStamp time.Time `json:"action_statement_timestamp,omitempty"`
+	ActionStatementTimestamp time.Time `json:"action_statement_timestamp,omitempty"`
 }
 
 // Validate checks to see whether the given Statement is valid. If it's not, an

--- a/pkg/vex/statement.go
+++ b/pkg/vex/statement.go
@@ -21,17 +21,17 @@ type Statement struct {
 	//
 	// [vul_id] MAY be URIs or URLs.
 	// [vul_id] MAY be arbitrary and MAY be created by the VEX statement [author].
-	Vulnerability   string `json:"vulnerability"`
+	Vulnerability   string `json:"vulnerability,omitempty"`
 	VulnDescription string `json:"vuln_description,omitempty"`
 
 	// Timestamp is the time at which the information expressed in the Statement
 	// was known to be true.
-	Timestamp time.Time `json:"timestamp"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
 
 	// ProductIdentifiers
 	// Product details MUST specify what Status applies to.
 	// Product details MUST include [product_id] and MAY include [subcomponent_id].
-	Products      []string `json:"products"`
+	Products      []string `json:"products,omitempty"`
 	Subcomponents []string `json:"subcomponents,omitempty"`
 
 	// A VEX statement MUST provide Status of the vulnerabilities with respect to the

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -177,7 +177,6 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 						Status:          StatusFromCSAF(status),
 						Justification:   "", // Justifications are not machine readable in csaf, it seems
 						ActionStatement: just,
-						References:      []VulnerabilityReference{},
 					})
 				}
 			}

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -34,12 +34,11 @@ type VEX struct {
 }
 
 type Metadata struct {
-	ID                 string    `json:"id"`                // Identifier string for the VEX document
-	Format             string    `json:"format"`            // VEX Format Identifier
-	Author             string    `json:"author"`            // Document author
-	AuthorRole         string    `json:"role"`              // Role of author
-	ProductIdentifiers []string  `json:"product,omitempty"` // For spec completeness
-	Timestamp          time.Time `json:"timestamp"`
+	ID         string    `json:"id"`     // Identifier string for the VEX document
+	Format     string    `json:"format"` // VEX Format Identifier
+	Author     string    `json:"author"` // Document author
+	AuthorRole string    `json:"role"`   // Role of author
+	Timestamp  time.Time `json:"timestamp"`
 }
 
 // VulnerabilityReference captures other identifier assigned to the CVE
@@ -51,9 +50,8 @@ type VulnerabilityReference struct {
 func New() VEX {
 	return VEX{
 		Metadata: Metadata{
-			Format:             formatIdentifier,
-			ProductIdentifiers: []string{},
-			Timestamp:          time.Now(),
+			Format:    formatIdentifier,
+			Timestamp: time.Now(),
 		},
 		Statements: []Statement{},
 	}
@@ -142,11 +140,10 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 	// Create the vex doc
 	v := &VEX{
 		Metadata: Metadata{
-			ID:                 csafDoc.Document.Tracking.ID,
-			Author:             "",
-			AuthorRole:         "",
-			ProductIdentifiers: products,
-			Timestamp:          time.Time{},
+			ID:         csafDoc.Document.Tracking.ID,
+			Author:     "",
+			AuthorRole: "",
+			Timestamp:  time.Time{},
 		},
 		Statements: []Statement{},
 	}
@@ -177,6 +174,7 @@ func OpenCSAF(path string, products []string) (*VEX, error) {
 						Status:          StatusFromCSAF(status),
 						Justification:   "", // Justifications are not machine readable in csaf, it seems
 						ActionStatement: just,
+						Products:        products,
 					})
 				}
 			}


### PR DESCRIPTION
This PR updates the VEX struct to add support for product details at the statement level plus other minor fields added to the minimum elements spec as of Dec 23. This PR has three parts:

### 1. Added missing fields to Statement
- vuln_description
- products
- subcomponents
- action_statement_timestamp

### 2. Removed `product` from the Document level.

The minimum requirements spec has it only at the statement.

### 3. Marked Vulnerability, Timestamp, and Product optional

Vulnerability, Timestamp, and Product in the Statement are now `omitempty` as they may be inherited from the document or encapsulating format.

/cc @luhring 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>