### PR TITLE
vexctl merge: Combine vex data sources into new doc

### DIFF
--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -51,6 +51,7 @@ func init() {
 
 	addFilter(rootCmd)
 	addAttest(rootCmd)
+	addMerge(rootCmd)
 	rootCmd.AddCommand(version.WithFont("doom"))
 }
 

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -58,6 +58,27 @@ Examples:
 		},
 	}
 
+	mergeCmd.PersistentFlags().StringVar(
+		&opts.DocumentID,
+		"docid",
+		"",
+		"ID for the new VEX document (default will be computed)",
+	)
+
+	mergeCmd.PersistentFlags().StringVar(
+		&opts.Author,
+		"author",
+		"unknown",
+		"author to record in the new document",
+	)
+
+	mergeCmd.PersistentFlags().StringVar(
+		&opts.AuthorRole,
+		"author-role",
+		"document creator",
+		"author role to record in the new document",
+	)
+
 	mergeCmd.PersistentFlags().StringSliceVar(
 		&opts.Vulnerabilities,
 		"vuln",

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"chainguard.dev/vex/pkg/ctl"
+)
+
+type mergeOptions struct {
+	ctl.MergeOptions
+}
+
+func addMerge(parentCmd *cobra.Command) {
+	opts := mergeOptions{}
+	mergeCmd := &cobra.Command{
+		Short: fmt.Sprintf("%s merge: merges two or more VEX documents into one", appname),
+		Long: fmt.Sprintf(`%s merge: merge one or more documents into one
+
+When composing VEX data out of multiple sources it may be necessary to mix
+all statements into a single doc. The merge subcommand mixes the statements
+from one or more vex documents into a single, new one.
+
+Examples:
+
+# Merge two documents into one
+%s merge document1.vex.json document2.vex.json > new.vex.json
+
+# Merge two documents into one, but only one product
+%s merge --product="pkg:apk/wolfi/bash@1.0" document1.vex.json document2.vex.json 
+
+# Merge vulnerability data from two documents into one
+%s merge --vulnerability=CVE-2022-3294 document1.vex.json document2.vex.json 
+
+`, appname, appname, appname, appname),
+		Use:               "merge",
+		SilenceUsage:      false,
+		SilenceErrors:     false,
+		PersistentPreRunE: initLogging,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			vexctl := ctl.New()
+			newVex, err := vexctl.MergeFiles(context.Background(), &opts.MergeOptions, args)
+			if err != nil {
+				return fmt.Errorf("merging documents: %w", err)
+			}
+			if err := newVex.ToJSON(os.Stdout); err != nil {
+				return fmt.Errorf("writing new vex document: %w", err)
+			}
+			return nil
+		},
+	}
+
+	mergeCmd.PersistentFlags().StringSliceVar(
+		&opts.Vulnerabilities,
+		"vuln",
+		[]string{},
+		"list of vulnerabilities to extract",
+	)
+
+	mergeCmd.PersistentFlags().StringSliceVar(
+		&opts.Products,
+		"product",
+		[]string{},
+		"list of products to merge, all others will be ignored",
+	)
+
+	parentCmd.AddCommand(mergeCmd)
+}

--- a/pkg/ctl/ctl.go
+++ b/pkg/ctl/ctl.go
@@ -124,14 +124,8 @@ func (vexctl *VexCtl) VexFromURI(ctx context.Context, uri string) (vexData *vex.
 }
 
 // Merge combines several documents into one
-func (vexctl *VexCtl) Merge(vexes []*vex.VEX) (*vex.VEX, error) {
-	// TODO: Pipe to flags
-	opts := MergeOptions{
-		Products:        []string{},
-		Vulnerabilities: []string{},
-	}
-
-	doc, err := vexctl.impl.Merge(opts, vexes)
+func (vexctl *VexCtl) Merge(ctx context.Context, opts *MergeOptions, vexes []*vex.VEX) (*vex.VEX, error) {
+	doc, err := vexctl.impl.Merge(ctx, opts, vexes)
 	if err != nil {
 		return nil, fmt.Errorf("merging %d documents: %w", len(vexes), err)
 	}
@@ -139,20 +133,14 @@ func (vexctl *VexCtl) Merge(vexes []*vex.VEX) (*vex.VEX, error) {
 }
 
 // MergeFiles is like Merge but takes filepaths instead of actual VEX documents
-func (vexctl *VexCtl) MergeFiles(filePaths []string) (*vex.VEX, error) {
-	vexes, err := vexctl.impl.LoadFiles(filePaths)
+func (vexctl *VexCtl) MergeFiles(ctx context.Context, opts *MergeOptions, filePaths []string) (*vex.VEX, error) {
+	vexes, err := vexctl.impl.LoadFiles(ctx, filePaths)
 	if err != nil {
 		return nil, fmt.Errorf("loading files: %w", err)
 	}
 
-	// TODO: Pipe to flags
-	opts := MergeOptions{
-		Products:        []string{},
-		Vulnerabilities: []string{},
-	}
-
 	// Merge'em Dano
-	doc, err := vexctl.impl.Merge(opts, vexes)
+	doc, err := vexctl.impl.Merge(ctx, opts, vexes)
 	if err != nil {
 		return nil, fmt.Errorf("merging %d documents: %w", len(vexes), err)
 	}

--- a/pkg/ctl/ctl.go
+++ b/pkg/ctl/ctl.go
@@ -122,3 +122,39 @@ func (vexctl *VexCtl) VexFromURI(ctx context.Context, uri string) (vexData *vex.
 	}
 	return vexData, err
 }
+
+// Merge combines several documents into one
+func (vexctl *VexCtl) Merge(vexes []*vex.VEX) (*vex.VEX, error) {
+	// TODO: Pipe to flags
+	opts := MergeOptions{
+		Products:        []string{},
+		Vulnerabilities: []string{},
+	}
+
+	doc, err := vexctl.impl.Merge(opts, vexes)
+	if err != nil {
+		return nil, fmt.Errorf("merging %d documents: %w", len(vexes), err)
+	}
+	return doc, nil
+}
+
+// MergeFiles is like Merge but takes filepaths instead of actual VEX documents
+func (vexctl *VexCtl) MergeFiles(filePaths []string) (*vex.VEX, error) {
+	vexes, err := vexctl.impl.LoadFiles(filePaths)
+	if err != nil {
+		return nil, fmt.Errorf("loading files: %w", err)
+	}
+
+	// TODO: Pipe to flags
+	opts := MergeOptions{
+		Products:        []string{},
+		Vulnerabilities: []string{},
+	}
+
+	// Merge'em Dano
+	doc, err := vexctl.impl.Merge(opts, vexes)
+	if err != nil {
+		return nil, fmt.Errorf("merging %d documents: %w", len(vexes), err)
+	}
+	return doc, nil
+}

--- a/pkg/ctl/ctl_test.go
+++ b/pkg/ctl/ctl_test.go
@@ -1,6 +1,7 @@
 package ctl
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,7 @@ func TestVexReport(t *testing.T) {
 }
 
 func TestMerge(t *testing.T) {
+	ctx := context.Background()
 	doc1, err := vex.Load("testdata/document1.vex.json")
 	require.NoError(t, err)
 	doc2, err := vex.Load("testdata/document1.vex.json")
@@ -69,7 +71,7 @@ func TestMerge(t *testing.T) {
 			shouldErr: false,
 		},
 	} {
-		doc, err := impl.Merge(tc.opts, tc.docs)
+		doc, err := impl.Merge(ctx, &tc.opts, tc.docs)
 		if tc.shouldErr {
 			require.Error(t, err)
 			continue

--- a/pkg/ctl/ctl_test.go
+++ b/pkg/ctl/ctl_test.go
@@ -41,7 +41,7 @@ func TestMerge(t *testing.T) {
 		expectedDoc *vex.VEX
 		shouldErr   bool
 	}{
-		// CeZero docs should fail
+		// Zero docs should fail
 		{
 			opts:        MergeOptions{},
 			docs:        []*vex.VEX{},

--- a/pkg/ctl/ctl_test.go
+++ b/pkg/ctl/ctl_test.go
@@ -1,3 +1,8 @@
+/*
+Copyright 2022 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package ctl
 
 import (

--- a/pkg/ctl/ctl_test.go
+++ b/pkg/ctl/ctl_test.go
@@ -27,3 +27,56 @@ func TestVexReport(t *testing.T) {
 	require.Len(t, newReport.Runs, 1)
 	require.Len(t, newReport.Runs[0].Results, 122)
 }
+
+func TestMerge(t *testing.T) {
+	doc1, err := vex.Load("testdata/document1.vex.json")
+	require.NoError(t, err)
+	doc2, err := vex.Load("testdata/document1.vex.json")
+	require.NoError(t, err)
+
+	impl := defaultVexCtlImplementation{}
+	for _, tc := range []struct {
+		opts        MergeOptions
+		docs        []*vex.VEX
+		expectedDoc *vex.VEX
+		shouldErr   bool
+	}{
+		// CeZero docs should fail
+		{
+			opts:        MergeOptions{},
+			docs:        []*vex.VEX{},
+			expectedDoc: &vex.VEX{},
+			shouldErr:   true,
+		},
+		// One doc results in the same doc
+		{
+			opts:        MergeOptions{},
+			docs:        []*vex.VEX{doc1},
+			expectedDoc: doc1,
+			shouldErr:   false,
+		},
+		// Two docs, as they are
+		{
+			opts: MergeOptions{},
+			docs: []*vex.VEX{doc1, doc2},
+			expectedDoc: &vex.VEX{
+				Metadata: vex.Metadata{},
+				Statements: []vex.Statement{
+					doc1.Statements[0],
+					doc2.Statements[0],
+				},
+			},
+			shouldErr: false,
+		},
+	} {
+		doc, err := impl.Merge(tc.opts, tc.docs)
+		if tc.shouldErr {
+			require.Error(t, err)
+			continue
+		}
+
+		// Check doc
+		require.Len(t, doc.Statements, len(tc.expectedDoc.Statements))
+		require.Equal(t, doc.Statements, tc.expectedDoc.Statements)
+	}
+}

--- a/pkg/ctl/implementation.go
+++ b/pkg/ctl/implementation.go
@@ -309,18 +309,19 @@ func (impl *defaultVexCtlImplementation) Merge(mergeOpts MergeOptions, docs []*v
 	}
 
 	for _, doc := range docs {
+	LOOP_STATEMENTS:
 		for _, s := range doc.Statements {
 			if len(iProds) > 0 {
-				for _, pid := range s.ProductIdentifiers {
+				for _, pid := range s.Products {
 					if _, ok := iProds[pid]; !ok {
-						continue
+						continue LOOP_STATEMENTS
 					}
 				}
 			}
 
 			if len(iVulns) > 0 {
 				if _, ok := iProds[s.Vulnerability]; !ok {
-					continue
+					continue LOOP_STATEMENTS
 				}
 			}
 

--- a/pkg/ctl/implementation.go
+++ b/pkg/ctl/implementation.go
@@ -281,7 +281,8 @@ type MergeOptions struct {
 }
 
 func (impl *defaultVexCtlImplementation) Merge(
-	_ context.Context, mergeOpts *MergeOptions, docs []*vex.VEX) (*vex.VEX, error) {
+	_ context.Context, mergeOpts *MergeOptions, docs []*vex.VEX,
+) (*vex.VEX, error) {
 	if len(docs) == 0 {
 		return nil, fmt.Errorf("at least one vex document is required to merge")
 	}
@@ -337,7 +338,7 @@ func (impl *defaultVexCtlImplementation) Merge(
 
 	for _, doc := range docs {
 	LOOP_STATEMENTS:
-		for _, s := range doc.Statements {
+		for _, s := range doc.Statements { //nolint:gocritic // this IS supposed to copy
 			if len(iProds) > 0 {
 				for _, pid := range s.Products {
 					if _, ok := iProds[pid]; !ok {
@@ -367,8 +368,9 @@ func (impl *defaultVexCtlImplementation) Merge(
 }
 
 // LoadFiles loads multiple vex files from disk
-func (di *defaultVexCtlImplementation) LoadFiles(
-	_ context.Context, filePaths []string) ([]*vex.VEX, error) {
+func (impl *defaultVexCtlImplementation) LoadFiles(
+	_ context.Context, filePaths []string,
+) ([]*vex.VEX, error) {
 	vexes := make([]*vex.VEX, len(filePaths))
 	for i, path := range filePaths {
 		doc, err := vex.Load(path)

--- a/pkg/ctl/implementation.go
+++ b/pkg/ctl/implementation.go
@@ -46,8 +46,8 @@ type Implementation interface {
 	Attach(context.Context, *attestation.Attestation, string) error
 	SourceType(uri string) (string, error)
 	ReadImageAttestations(context.Context, Options, string) ([]*vex.VEX, error)
-	Merge(MergeOptions, []*vex.VEX) (*vex.VEX, error)
-	LoadFiles([]string) ([]*vex.VEX, error)
+	Merge(context.Context, *MergeOptions, []*vex.VEX) (*vex.VEX, error)
+	LoadFiles(context.Context, []string) ([]*vex.VEX, error)
 }
 
 type defaultVexCtlImplementation struct{}
@@ -275,7 +275,8 @@ type MergeOptions struct {
 	Vulnerabilities []string // IDs of vulnerabilities to merge
 }
 
-func (impl *defaultVexCtlImplementation) Merge(mergeOpts MergeOptions, docs []*vex.VEX) (*vex.VEX, error) {
+func (impl *defaultVexCtlImplementation) Merge(
+	_ context.Context, mergeOpts *MergeOptions, docs []*vex.VEX) (*vex.VEX, error) {
 	if len(docs) == 0 {
 		return nil, fmt.Errorf("at least one vex document is required to merge")
 	}
@@ -340,7 +341,8 @@ func (impl *defaultVexCtlImplementation) Merge(mergeOpts MergeOptions, docs []*v
 }
 
 // LoadFiles loads multiple vex files from disk
-func (di *defaultVexCtlImplementation) LoadFiles(filePaths []string) ([]*vex.VEX, error) {
+func (di *defaultVexCtlImplementation) LoadFiles(
+	_ context.Context, filePaths []string) ([]*vex.VEX, error) {
 	vexes := make([]*vex.VEX, len(filePaths))
 	for i, path := range filePaths {
 		doc, err := vex.Load(path)

--- a/pkg/ctl/testdata/document1.vex.json
+++ b/pkg/ctl/testdata/document1.vex.json
@@ -1,0 +1,15 @@
+{
+    "id": "my-vexdoc",
+	"format": "text/vex+json",
+	"author": "John Doe",
+	"role": "vex issuer",	
+	"statements": [
+        {
+            "timestamp": "2022-12-22T20:56:05-05:00",
+            "product_id": ["pkg:apk/wolfi/bash@1.0.0"],
+            "vul_id": "CVE-1234-5678",
+            "status": "under_investigation",
+            "status_notes": ""
+        }
+    ]
+}

--- a/pkg/ctl/testdata/document2.vex.json
+++ b/pkg/ctl/testdata/document2.vex.json
@@ -1,0 +1,14 @@
+{
+    "id": "my-vexdoc",
+	"format": "text/vex+json",
+	"author": "John Doe",
+	"role": "vex issuer",	
+    "statements": [
+        {
+            "timestamp": "2022-12-22T20:56:05-05:00",
+            "product_id": ["pkg:apk/wolfi/bash@1.0.0"],
+            "vul_id": "CVE-1234-5678",
+            "status": "affected"
+        }
+    ]
+}

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -57,6 +57,19 @@ func New() VEX {
 	}
 }
 
+func Load(path string) (*VEX, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("loading vex file: %w", err)
+	}
+
+	vexDoc := &VEX{}
+	if err := json.Unmarshal(data, vexDoc); err != nil {
+		return nil, fmt.Errorf("unmarshaling VEX document: %w", err)
+	}
+	return vexDoc, nil
+}
+
 func OpenYAML(path string) (*VEX, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
This PR introduces new functionality into vexctl to merge vex data from various sources into one document.

The functionality is baked into the `ctl` package and its implementation and it is also exposed in a new CLI subcommand `vexctl merge`.  Here's an example using the included test documents:

```
go run ./main.go  merge ./pkg/ctl/testdata/document1.vex.json ./pkg/ctl/testdata/document2.vex.json
{
  "id": "merged-vex-4d11a8a0f5138a44c61161655e36393b871d4439380eae14bd3c2d66f5ee3873",
  "format": "text/vex",
  "author": "unknown",
  "role": "document creator",
  "timestamp": "2022-12-23T14:55:34.18948616-06:00",
  "statements": [
    {
      "timestamp": "2022-12-22T20:56:05-05:00",
      "status": "under_investigation",
    },
    {
      "timestamp": "2022-12-22T20:56:05-05:00",
      "status": "affected",
    }
  ]
}
```
The new subcommand can receive product IDs and vulnerability identifiers to compose a new document using only the specified bits.