### PR TITLE
Expose default author and roles

### DIFF
--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"chainguard.dev/vex/pkg/ctl"
+	"chainguard.dev/vex/pkg/vex"
 )
 
 type mergeOptions struct {
@@ -68,14 +69,14 @@ Examples:
 	mergeCmd.PersistentFlags().StringVar(
 		&opts.Author,
 		"author",
-		"unknown",
+		vex.DefaultAuthor,
 		"author to record in the new document",
 	)
 
 	mergeCmd.PersistentFlags().StringVar(
 		&opts.AuthorRole,
 		"author-role",
-		"document creator",
+		vex.DefaultRole,
 		"author role to record in the new document",
 	)
 

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -26,6 +26,12 @@ const (
 
 	// MIME type to record in the attestations
 	MimeType = "text/vex"
+
+	// Default author for documents
+	DefaultAuthor = "Unknown Author"
+
+	// DefaultRole to list when not having a role
+	DefaultRole = "Document Creator"
 )
 
 type VEX struct {


### PR DESCRIPTION
We now expose default strings for document author and its role to ensure we have a consistent default string in tools using the VEX package.

/cc @luhring 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>