### PR TITLE
Enable json-ld !

### DIFF
--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -38,6 +38,9 @@ const (
 
 	// Context is the URL of the json-ld context definition
 	Context = "https://openvex.dev/ns"
+
+	// PublicNamespace is the public openvex namespace for common @ids
+	PublicNamespace = "https://openvex.dev/docs"
 )
 
 // The VEX type represents a VEX document and all of its contained information.
@@ -311,7 +314,8 @@ func (vexDoc *VEX) GenerateCanonicalID() (string, error) {
 		return "", fmt.Errorf("getting canonical hash: %w", err)
 	}
 
-	vexDoc.ID = fmt.Sprintf("VEX-%s", cHash)
+	// For common namespaced documents we namespace them into /public
+	vexDoc.ID = fmt.Sprintf("%s/public/vex-%s", PublicNamespace, cHash)
 	return vexDoc.ID, nil
 }
 

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -35,6 +35,9 @@ const (
 
 	// DefaultRole is the default value for a document's AuthorRole field.
 	DefaultRole = "Document Creator"
+
+	// Context is the URL of the json-ld context definition
+	Context = "https://openvex.dev/ns"
 )
 
 // The VEX type represents a VEX document and all of its contained information.
@@ -45,9 +48,12 @@ type VEX struct {
 
 // The Metadata type represents the metadata associated with a VEX document.
 type Metadata struct {
+	// Context is the URL pointing to the jsonld context definition
+	Context string `json:"@context"`
+
 	// ID is the identifying string for the VEX document. This should be unique per
 	// document.
-	ID string `json:"id"`
+	ID string `json:"@id"`
 
 	// Author is the identifier for the author of the VEX statement, ideally a common
 	// name, may be a URI. [author] is an individual or organization. [author]

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -93,6 +93,7 @@ func New() VEX {
 	}
 	return VEX{
 		Metadata: Metadata{
+			Context:    Context,
 			Author:     DefaultAuthor,
 			AuthorRole: DefaultRole,
 			Version:    "1",

--- a/pkg/vex/vex_test.go
+++ b/pkg/vex/vex_test.go
@@ -146,7 +146,7 @@ func TestGenerateCanonicalID(t *testing.T) {
 		{
 			// Normal generation
 			prepare:    func(v *VEX) {},
-			expectedID: "VEX-461bb1de8d85c7a6af96edf24d0e0672726d248500e63c5413f89db0c6710fa0",
+			expectedID: "https://openvex.dev/docs/public/vex-461bb1de8d85c7a6af96edf24d0e0672726d248500e63c5413f89db0c6710fa0",
 		},
 		{
 			// Existing IDs should not be changed


### PR DESCRIPTION
This PR modifies the json output of the VEX object to make our documents json-ld compatible. This is achieved by:

1. Changes the ID label in the json doc to @id
2. Adds the @context field
3. Creates a public namespace for shared document IDs and adds a constant with the context definition location

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>
