### PR TITLE
Last changes from jan 9th meeting

### DIFF
--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -68,6 +68,7 @@ type vexStatementOptions struct {
 	Justification   string
 	ImpactStatement string
 	Vulnerability   string
+	ActionStatement string
 	Products        []string
 	Subcomponents   []string
 }

--- a/pkg/vex/statement.go
+++ b/pkg/vex/statement.go
@@ -93,6 +93,11 @@ func (stmt Statement) Validate() error { //nolint:gocritic // turning off for ru
 			return fmt.Errorf("impact statement should not be set when using status %q (was set to %q)", s, v)
 		}
 
+		// action statement is now required
+		if v := stmt.ActionStatement; v == "" {
+			return fmt.Errorf("action statement must be set when using status %q", s)
+		}
+
 	case StatusUnderInvestigation:
 		// irrelevant fields should not be set
 		if v := stmt.Justification; v != "" {

--- a/pkg/vex/statement.go
+++ b/pkg/vex/statement.go
@@ -51,7 +51,7 @@ type Statement struct {
 	// that contains a description why the vulnerability cannot be exploited.
 	ImpactStatement string `json:"impact_statement,omitempty"`
 
-	// For "affected" status, a VEX statement MAY include an ActionStatement that
+	// For "affected" status, a VEX statement MUST include an ActionStatement that
 	// SHOULD describe actions to remediate or mitigate [vul_id].
 	ActionStatement          string     `json:"action_statement,omitempty"`
 	ActionStatementTimestamp *time.Time `json:"action_statement_timestamp,omitempty"`

--- a/pkg/vex/statement.go
+++ b/pkg/vex/statement.go
@@ -69,11 +69,12 @@ func (stmt Statement) Validate() error { //nolint:gocritic // turning off for ru
 	case StatusNotAffected:
 		// require a justification
 		j := stmt.Justification
-		if j == "" {
-			return fmt.Errorf("justification missing, it's required when using status %q", s)
+		is := stmt.ImpactStatement
+		if j == "" && is == "" {
+			return fmt.Errorf("either justification or impact statement must be defined when using status %q", s)
 		}
 
-		if !j.Valid() {
+		if j != "" && !j.Valid() {
 			return fmt.Errorf("invalid justification value %q, must be one of [%s]", j, strings.Join(Justifications(), ", "))
 		}
 

--- a/pkg/vex/vex.go
+++ b/pkg/vex/vex.go
@@ -41,6 +41,9 @@ const (
 
 	// PublicNamespace is the public openvex namespace for common @ids
 	PublicNamespace = "https://openvex.dev/docs"
+
+	// NoActionStatementMsg is the action statement that informs that there is no action statement :/
+	NoActionStatementMsg = "No action statement provided"
 )
 
 // The VEX type represents a VEX document and all of its contained information.


### PR DESCRIPTION
This commit updates vez and the vexctl tool to incorporate the last changes to the data model decided on the Jan 9th meeting:"

- Action Statement is now required on `affected` statements
- Either Justification or Impact statement are required when  status is`not_affected` 

It also modifies the `create` subcommand to supply a default action statement and to use the Statement validator, ditching its own logic in favor of the vex package validator.